### PR TITLE
Add more outputs to sampler

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,17 @@ Finally, we setup the DRAM sampler, here I expose all the parameters. In practic
 
 This is now a simple iterator. So you can iterate forever with
 
-    for sample, logpdf, accepted_bool in sampler:
+    for sample, logpdf, accepted_bool, state in sampler:
         print(f"Sample: {sample}")
         print(f"\t Logpdf: {logpdf}")
         print(f"\t Accepted? -> {accepted_bool}")
+        print(f"\t Proposed sample: {state.proposed_samples[0]}")
+        print(f"\t Proposed logpdf: {state.proposed_logpdfs[0]}")
+        print(f"\t Proposal covariance: {state.cov}")
         print("\n")
         
-Notice that the sampler outputs three things: the next sample, the evaluation of the logpdf, and whether or not this is a new sample that was accepted (True) or an old sample wjere a new sample was proposed, but rejected (False)
+Notice that the sampler outputs for things: the next sample, the evaluation of the logpdf, whether or not this is a new sample that was accepted (True) or an old sample where a new sample was proposed, but rejected (False), and the sampler state.
+This last variable in turn contains the proposed sample (or samples, in the case of delayed-rejection methods), the proposed logpdf(s), and the covariance of the proposal distribution.
 
 One can use this iterator in conjuction with any itertools functions. For instance the following function turns this iterator into one with a finite number of samples (100)
 
@@ -55,7 +59,7 @@ One can use this iterator in conjuction with any itertools functions. For instan
     
 One can also extract just the samples, rather than the logpdf values and whether or not it is an accepted sample via
 
-    sampler = itertools.starmap(lambda x, y, z: x, sampler)
+    sampler = itertools.starmap(lambda x, y, z, s: x, sampler)
     
 Finally, one could put the samples into a pandas dataframe as follows
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ First you construct a function to evaluate the logpdf of a shifted and skewed Ga
 
     def gauss_logpdf(x):
         cov = np.array([[1.0, 0.2], 
-                         0.2, 2.0])
+                        [0.2, 2.0]])
         mean = np.array([1.0, 2.0])
         
         diff = x - mean
@@ -33,9 +33,9 @@ Next we setup the sampler. For the initial sample we will use a zero vector and 
                          
 Finally, we setup the DRAM sampler, here I expose all the parameters. In practice you can use the defaults.
     
-    sampler = DelayedRejectionAdaptiveMetropolis(gauss_logpdf, init_sample, init_cov
+    sampler = DelayedRejectionAdaptiveMetropolis(gauss_logpdf, init_sample, init_cov,
                                                  adapt_start=10,
-                                                 eps=1e-6, sd=None
+                                                 eps=1e-6, sd=None,
                                                  interval=1, level_scale=1e-1)
 
 

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -53,7 +53,7 @@ class TestRandomWalkGaussSampler(unittest.TestCase):
                                                                  mean=cls.mean,
                                                                  cov=cls.cov)
         mh = samplers.RandomWalkGauss(logpdf_f, cls.mean, cls.cov*0.8)
-        mh2 = itertools.starmap(lambda x,y,z: x, itertools.islice(mh, cls.num_samples))
+        mh2 = itertools.starmap(lambda x,y,z,s: x, itertools.islice(mh, cls.num_samples))
         cls.df = pd.DataFrame(mh2)
         
     def test_count(self):
@@ -91,7 +91,7 @@ class TestAdaptiveMetropolisGaussSampler(unittest.TestCase):
                                               adapt_start = adapt_start,
                                               eps=1e-6, sd=2.4**2 / cls.cov.shape[0],
                                               interval=interval)
-        mh2 = itertools.starmap(lambda x,y,z: x, itertools.islice(mh, cls.num_samples))
+        mh2 = itertools.starmap(lambda x,y,z,s: x, itertools.islice(mh, cls.num_samples))
         cls.df = pd.DataFrame(mh2)
         
     def test_count(self):
@@ -125,7 +125,7 @@ class TestDelayedRejectionGaussSampler(unittest.TestCase):
                                                                  cov=cls.cov)
         
         mh = samplers.DelayedRejectionGauss(logpdf_f, cls.mean, 0.2*np.eye(2), level_scale=1e-2)
-        mh2 = itertools.starmap(lambda x,y,z: x, itertools.islice(mh, cls.num_samples))
+        mh2 = itertools.starmap(lambda x,y,z,s: x, itertools.islice(mh, cls.num_samples))
         cls.df = pd.DataFrame(mh2)
 
     def test_count(self):
@@ -164,7 +164,7 @@ class TestDelayedRejectionAdaptiveMetropolisGaussSampler(unittest.TestCase):
                                                          eps=1e-6, sd=2.4**2 / cls.cov.shape[0],
                                                          interval=10,
                                                          level_scale=1e-2)
-        mh2 = itertools.starmap(lambda x,y,z: x, itertools.islice(mh, cls.num_samples))
+        mh2 = itertools.starmap(lambda x,y,z,s: x, itertools.islice(mh, cls.num_samples))
         cls.df = pd.DataFrame(mh2)
 
     def test_count(self):


### PR DESCRIPTION
This PR adds an additional output to the sampler iterator -- the sampler state. For now, this includes three variables. These are
1. `proposed_samples`: a list of the samples proposed at that step (usually length 1, but length 2 if using DR),
2. `proposed_logpdfs`: the log-posteriors at the above, and,
3. `cov`: the current proposal covariance, if present.

It also updates the readme and tests in light of these changes